### PR TITLE
Add resizePolicy support for in-place pod resize (K8s 1.33 beta)

### DIFF
--- a/application/Chart.yaml
+++ b/application/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # Helm chart Version
 
-version: 2.1.14
+version: 2.2.0
 
 
 keywords:

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -266,6 +266,10 @@ spec:
           requests:
             memory: {{ .Values.deployment.resources.requests.memory }}
             cpu: {{ .Values.deployment.resources.requests.cpu }}
+        {{- with .Values.deployment.resizePolicy }}
+        resizePolicy:
+{{ toYaml . | indent 8 }}
+        {{- end }}
         {{- if .Values.deployment.containerSecurityContext }}
         securityContext:
 {{ toYaml .Values.deployment.containerSecurityContext | indent 10 }}

--- a/application/templates/statefulset.yaml
+++ b/application/templates/statefulset.yaml
@@ -199,6 +199,10 @@ spec:
           requests:
             memory: {{ .Values.statefulSet.resources.requests.memory }}
             cpu: {{ .Values.statefulSet.resources.requests.cpu }}
+        {{- with .Values.statefulSet.resizePolicy }}
+        resizePolicy:
+{{ toYaml . | indent 8 }}
+        {{- end }}
         {{- if .Values.statefulSet.containerSecurityContext }}
         securityContext:
 {{ toYaml .Values.statefulSet.containerSecurityContext | indent 10 }}

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -242,6 +242,18 @@ deployment:
       memory: 128Mi
       cpu: 0.1
 
+  # Per-resource restart behavior for in-place pod resize (Kubernetes 1.27+
+  # alpha, 1.33+ beta/default-on). Without this block the API server applies
+  # NotRequired for both — meaning resource changes are applied to the running
+  # container with no restart. Set RestartContainer for cpu or memory if your
+  # app re-reads limits only at startup (most JVMs, runtimes pinned via
+  # GOMEMLIMIT/cgroup probes, etc.).
+  # resizePolicy:
+  #   - resourceName: cpu
+  #     restartPolicy: NotRequired
+  #   - resourceName: memory
+  #     restartPolicy: RestartContainer
+
   #  Security Context at Container Level
   containerSecurityContext:
     readOnlyRootFilesystem: true
@@ -488,6 +500,18 @@ statefulSet:
     requests:
       memory: 128Mi
       cpu: 0.1
+
+  # Per-resource restart behavior for in-place pod resize (Kubernetes 1.27+
+  # alpha, 1.33+ beta/default-on). Without this block the API server applies
+  # NotRequired for both — meaning resource changes are applied to the running
+  # container with no restart. Set RestartContainer for cpu or memory if your
+  # app re-reads limits only at startup (most JVMs, runtimes pinned via
+  # GOMEMLIMIT/cgroup probes, etc.).
+  # resizePolicy:
+  #   - resourceName: cpu
+  #     restartPolicy: NotRequired
+  #   - resourceName: memory
+  #     restartPolicy: RestartContainer
 
   #  Security Context at Container Level
   containerSecurityContext:


### PR DESCRIPTION
In-place pod resize moved to beta and is enabled by default in K8s 1.33, making spec.containers[*].resources mutable on running pods. The optional spec.containers[*].resizePolicy lets the chart user pin per-resource restart behavior; without it the API server defaults to NotRequired for both cpu and memory and applies updates without restarting the container.

Surface it as deployment.resizePolicy / statefulSet.resizePolicy. Both are omitted from the rendered manifest when unset, so existing releases see no diff. Skipping cronjob.resizePolicy intentionally — Jobs are short-lived and don't benefit from in-place resize.

Bumps chart 2.1.14 -> 2.2.0 (additive feature).