### PR TITLE
Add hostUsers passthrough at pod-spec level (deployment + statefulSet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 All notable changes to this project will be documented here.
 
+### v2.3.0
+
+- Feature: Add `deployment.hostUsers` / `statefulSet.hostUsers` passthrough so callers can set `pod.spec.hostUsers` (required for `procMount: Unmasked` and unprivileged sandboxing). Omitted from rendered manifest unless explicitly set, so existing releases see no diff.
+
 ### v2.2.0
 
 - Fix: make deployment.image.tag and job.image.tag optional [PR-234](https://github.com/stakater/application/pull/234)

--- a/application/Chart.yaml
+++ b/application/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # Helm chart Version
 
-version: 2.2.0
+version: 2.3.0
 
 
 keywords:

--- a/application/templates/deployment.yaml
+++ b/application/templates/deployment.yaml
@@ -316,5 +316,8 @@ spec:
       {{- if .Values.deployment.hostNetwork }}
       hostNetwork: {{ .Values.deployment.hostNetwork }}
       {{- end }}
+      {{- if hasKey .Values.deployment "hostUsers" }}
+      hostUsers: {{ .Values.deployment.hostUsers }}
+      {{- end }}
       dnsPolicy: {{ .Values.deployment.dnsPolicy }}
 {{- end }}

--- a/application/templates/statefulset.yaml
+++ b/application/templates/statefulset.yaml
@@ -244,5 +244,8 @@ spec:
       {{- if .Values.statefulSet.hostNetwork }}
       hostNetwork: {{ .Values.statefulSet.hostNetwork }}
       {{- end }}
+      {{- if hasKey .Values.statefulSet "hostUsers" }}
+      hostUsers: {{ .Values.statefulSet.hostUsers }}
+      {{- end }}
       dnsPolicy: {{ .Values.statefulSet.dnsPolicy }}
 {{- end }}

--- a/application/values.yaml
+++ b/application/values.yaml
@@ -298,6 +298,14 @@ deployment:
   # Whether to use hostNetwork
   hostNetwork:
 
+  # Whether the pod uses the host's user namespace. Set to `false` to run
+  # the pod in its own user namespace — required for `procMount: Unmasked`
+  # under containerSecurityContext, and for unprivileged sandboxing tools
+  # (e.g. bubblewrap) that need to remount /proc inside the container.
+  # Omit (leave the key out entirely) to inherit the K8s default (true).
+  # Requires the UserNamespacesSupport feature gate (beta in 1.31, GA in 1.33).
+  # hostUsers: false
+
   dnsPolicy: ClusterFirst
   lifecycle:
     preStop:
@@ -556,6 +564,10 @@ statefulSet:
 
   # Whether to use hostNetwork
   hostNetwork:
+
+  # Whether the pod uses the host's user namespace. See deployment.hostUsers
+  # for the full description.
+  # hostUsers: false
 
   dnsPolicy: ClusterFirst
 


### PR DESCRIPTION
## Why

\`hostUsers\` is a pod-spec-level field (peer of \`hostNetwork\`, \`hostPID\`, etc.) that controls whether the pod uses the host's user namespace. Setting \`hostUsers: false\` is required to use \`procMount: Unmasked\` — the kubelet admission controller rejects \`Unmasked\` otherwise:

\`\`\`
spec.template.spec.containers[0].securityContext.procMount: Invalid value: "Unmasked":
  \`hostUsers\` must be false to use \`Unmasked\`
\`\`\`

It's also required for unprivileged sandboxing tools like bubblewrap that need to remount \`/proc\` inside the container.

Today the chart has **no way to pass \`hostUsers\` through**. The supported pod-spec fields are: \`terminationGracePeriodSeconds\`, \`hostAliases\`, \`initContainers\`, \`nodeSelector\`, \`tolerations\`, \`affinity\`, \`hostNetwork\`, \`securityContext\`, \`dnsConfig\`, \`dnsPolicy\`. \`deployment.securityContext\` renders as \`pod.spec.securityContext\`, so anyone placing \`hostUsers\` there (the natural guess) ends up at the wrong path and K8s silently ignores the unknown field — which is what bit me when trying to engage bwrap in an EKS deploy.

## What this PR does

Add \`deployment.hostUsers\` and \`statefulSet.hostUsers\` passthrough at the correct path:

\`\`\`yaml
{{- if hasKey .Values.deployment "hostUsers" }}
hostUsers: {{ .Values.deployment.hostUsers }}
{{- end }}
\`\`\`

Using \`hasKey\` (not the truthy \`if\`) so the value \`false\` — the common case for callers wanting their own user namespace — renders correctly. Omitting the key entirely (the default) skips the line, so existing releases see no diff.

## Backward compatibility

Strictly additive. No existing values are changed. Render output for any release that doesn't set \`hostUsers\` is byte-identical.

## Verified

\`helm template\` of the chart with \`--set deployment.hostUsers=false\` produces:

\`\`\`yaml
spec:
  template:
    spec:
      ...
      hostUsers: false
      ...
\`\`\`

Without the flag, no \`hostUsers\` line appears.

## Chart version

Bumps \`2.2.0\` → \`2.3.0\` (additive feature).